### PR TITLE
fix(GeminiSymptomService): validate response shape and normalize urgencyLevel (#61)

### DIFF
--- a/src/services/GeminiSymptomService.ts
+++ b/src/services/GeminiSymptomService.ts
@@ -180,24 +180,91 @@ class GeminiSymptomService {
   }
 
   
+  // Maps a canonical urgency level to the numeric severity the UI consumes.
+  private static readonly SEVERITY_MAP: Record<GeminiResponse['urgencyLevel'], number> = {
+    low: 1,
+    medium: 2,
+    high: 3,
+    emergency: 4
+  };
+
+  // Common ways the model deviates from the exact enum, mapped to the canonical
+  // value. Anything not covered here (or by the canonical keys themselves) is
+  // treated as unrecognized -> we surface an "unable to assess" error rather
+  // than silently downgrading to "low".
+  private static readonly URGENCY_SYNONYMS: Record<string, GeminiResponse['urgencyLevel']> = {
+    urgent: 'emergency',
+    critical: 'emergency',
+    severe: 'emergency',
+    moderate: 'medium',
+    mild: 'low'
+  };
+
+  // Normalize the model's urgencyLevel: trim + lowercase, then resolve canonical
+  // values and known synonyms. Returns null if the value cannot be safely
+  // interpreted, so the caller can fail to a validation state instead of
+  // guessing a clinical severity from malformed output.
+  private normalizeUrgencyLevel(raw: unknown): GeminiResponse['urgencyLevel'] | null {
+    if (typeof raw !== 'string') {
+      return null;
+    }
+    const value = raw.trim().toLowerCase();
+    if (value in GeminiSymptomService.SEVERITY_MAP) {
+      return value as GeminiResponse['urgencyLevel'];
+    }
+    if (value in GeminiSymptomService.URGENCY_SYNONYMS) {
+      return GeminiSymptomService.URGENCY_SYNONYMS[value];
+    }
+    return null;
+  }
+
+  // Runtime validation that the parsed object actually matches the shape the
+  // `as GeminiResponse` cast only promises at compile time. Throws a specific
+  // error so the UI can show a meaningful retry/consult state.
+  private validateGeminiResponse(resp: GeminiResponse): void {
+    if (!resp || typeof resp !== 'object') {
+      throw new Error('Symptom analysis returned an empty or malformed result.');
+    }
+    if (!Array.isArray(resp.possibleConditions) || resp.possibleConditions.length === 0) {
+      throw new Error('Symptom analysis did not return any possible conditions.');
+    }
+    const everyConditionValid = resp.possibleConditions.every(
+      (c) => c && typeof c.name === 'string' && typeof c.description === 'string'
+    );
+    if (!everyConditionValid) {
+      throw new Error('Symptom analysis returned an incomplete condition entry.');
+    }
+    if (!Array.isArray(resp.recommendations)) {
+      throw new Error('Symptom analysis did not return recommendations.');
+    }
+  }
+
   private processGeminiResponse(geminiResponse: GeminiResponse, originalSymptoms: string): SymptomResult {
-    
-    const severityMap: Record<string, number> = {
-      'low': 1,
-      'medium': 2,
-      'high': 3,
-      'emergency': 4
-    };
-    
-   
+    // Validate the parsed shape before consuming any fields, so a
+    // malformed-but-successful response surfaces a clear error instead of
+    // crashing on .map or silently dropping data.
+    this.validateGeminiResponse(geminiResponse);
+
+    // Resolve urgency safely. An unrecognized value is NOT downgraded to "low";
+    // it raises a validation error so the user is told the result could not be
+    // assessed rather than being shown a potentially dangerous "mild" reading.
+    const normalizedUrgency = this.normalizeUrgencyLevel(geminiResponse.urgencyLevel);
+    if (normalizedUrgency === null) {
+      throw new Error(
+        `Unable to assess urgency from the analysis (received: ${JSON.stringify(
+          geminiResponse.urgencyLevel
+        )}). Please try again or consult a doctor.`
+      );
+    }
+
     return {
-      summary: this.generateSummary(geminiResponse, originalSymptoms),
+      summary: this.generateSummary({ ...geminiResponse, urgencyLevel: normalizedUrgency }, originalSymptoms),
       possibleConditions: geminiResponse.possibleConditions.map(condition => ({
         name: condition.name,
-        probability: condition.probability * 100, 
+        probability: condition.probability * 100,
         description: condition.description
       })),
-      severity: severityMap[geminiResponse.urgencyLevel] || 1,
+      severity: GeminiSymptomService.SEVERITY_MAP[normalizedUrgency],
       recommendations: geminiResponse.recommendations,
       requiresAttention: geminiResponse.requiresAttention,
       disclaimer: geminiResponse.disclaimer,


### PR DESCRIPTION
Closes #61

## The bug

`processGeminiResponse` cast the parsed JSON `as GeminiResponse` (compile-time only) and then mapped `urgencyLevel` through a strict-key lookup with a `|| 1` fallback:

```ts
severity: severityMap[geminiResponse.urgencyLevel] || 1,
```

Any deviation in the model's output — capitalisation (`"Emergency"`), a synonym (`"urgent"`, `"critical"`), or a trailing space — resolves to `undefined`, which falls back to `1` (low). In a symptom checker this means a correctly-identified emergency is silently displayed as **mild**, suppressing the emergency UI banner (`severity === 4` in `SymptomResults.tsx`).

Measured against realistic model outputs:

| urgencyLevel from model | Old severity | Old UI label |
|---|---|---|
| `"emergency"` | 4 | Emergency ✅ |
| `"Emergency"` | **1** | **Mild** ❌ |
| `"EMERGENCY"` | **1** | **Mild** ❌ |
| `"urgent"` | **1** | **Mild** ❌ |
| `"critical"` | **1** | **Mild** ❌ |
| `"emergency "` (trailing space) | **1** | **Mild** ❌ |

The same `as GeminiResponse` cast also meant `possibleConditions.map(...)` could throw an unhandled `TypeError` if the model omitted that field, surfacing as a generic "Failed to analyze symptoms" outage rather than a meaningful retry state.

## The fix (single file: `src/services/GeminiSymptomService.ts`)

Three additions, no new dependencies:

### 1. `validateGeminiResponse()` — runtime shape check
Runs before any field is consumed. Confirms `possibleConditions` is a non-empty array with valid entries and `recommendations` is an array. Throws a specific, readable error on failure so the catch path in `analyzeSymptoms` produces a meaningful retry state instead of crashing on `.map`.

### 2. `normalizeUrgencyLevel()` — trim + lowercase + synonym resolution
- Trims whitespace and lowercases the raw value
- Maps canonical values (`low/medium/high/emergency`) through directly
- Maps known synonyms: `urgent/critical/severe → emergency`, `moderate → medium`, `mild → low`
- Returns `null` for anything unrecognisable (not silently to low **or** emergency)

### 3. Explicit "unable to assess" error on unrecognised urgency
Per your feedback: unknown values are **not** silently mapped to either extreme. `normalizeUrgencyLevel` returning `null` throws:
> "Unable to assess urgency from the analysis (received: ...). Please try again or consult a doctor."

This surfaces via the existing catch in `analyzeSymptoms` as a clean retry/consult state.

### Bonus: summary text consistency
`generateSummary` now receives `{ ...geminiResponse, urgencyLevel: normalizedUrgency }` so `getUrgencyText` also sees the normalised value. Without this, a capitalised `"Emergency"` would have hit `getUrgencyText`'s `default` branch and produced a "mild" summary sentence even after the severity was fixed.

## Post-fix behavior

| urgencyLevel from model | Severity | UI label |
|---|---|---|
| `"emergency"` / `"Emergency"` / `"EMERGENCY"` | 4 | Emergency ✅ |
| `"urgent"` / `"critical"` / `"severe"` | 4 | Emergency ✅ |
| `"high"` / `"High"` | 3 | Moderate ✅ |
| `"medium"` / `"moderate"` | 2 | Moderate ✅ |
| `"low"` / `"mild"` | 1 | Mild ✅ |
| `"xyz"` / `null` / any unrecognised | — | Throws → retry state ✅ |

## Verification

- `npx tsc --noEmit` — 0 errors
- `npx eslint src/services/GeminiSymptomService.ts` — clean
- `npm run build` — ✓ built successfully
- 21-case behavioral matrix verified (all canonical values, all synonym forms, all unrecognised inputs)
- No behaviour change on valid, well-formed model output

**Honest note:** I was not able to run a live end-to-end test with a real Gemini API key (no access to the project's key). The normalization and validation logic is unit-proven and the build is clean, but I'd appreciate your eyes on the integration — particularly whether the "unable to assess" error message surfaces correctly in the UI retry state.